### PR TITLE
Change to compatible device tree configuration

### DIFF
--- a/mfd-ch347.c
+++ b/mfd-ch347.c
@@ -20,6 +20,7 @@
 #include <linux/delay.h>
 #include <linux/completion.h>
 #include <linux/jiffies.h>
+#include <linux/of_device.h>
 
 #include "ch347.h"
 
@@ -89,9 +90,9 @@ struct ch347_dev {
 };
 
 static const struct mfd_cell ch347_devs[] = {
-	{ .name = "ch347-gpio", },
-	{ .name = "ch347-i2c", },
-	{ .name = "ch347-spi", }, // must be last -- optional
+	{ .name = "ch347-gpio", .of_compatible = "wch,ch347-mfd-gpio" },
+	{ .name = "ch347-i2c",  .of_compatible = "wch,ch347-mfd-i2c" },
+	{ .name = "ch347-spi",  .of_compatible = "wch,ch347-mfd-spi" }
 };
 
 static struct ch347_urb *ch347_urb_alloc(struct ch347_dev *ch347, unsigned size)


### PR DESCRIPTION
According to the reference document of the kernel's USB device tree, I made the above modifications. After the modification, the CH347 and its sub-devices can be configured into the device tree file in a similar way to the following method.

https://www.kernel.org/doc/Documentation/devicetree/bindings/usb/usb-device.txt

```
&usb1 {	/* host controller */
	#address-cells = <1>;
	#size-cells = <0>;

	hub@1 {		/* hub connected to port 1 */
		compatible = "usb5e3,608";
		reg = <1>;
	};

	device@2 {	/* device connected to port 2 */
		compatible = "usb123,4567";
		reg = <2>;
	};

	ch347@3 {
		compatible = "usb1a86,55db";
		reg = <3>;

		#address-cells = <2>;
		#size-cells = <0>;

		ch347-usb-if@2 {
			compatible = "usb1a86,55db.config1.2";
			reg = <2 1>;

			ch347-gpio {
				compatible = "wch,ch347-mfd-gpio";
			};

			ch347-i2c {
				compatible = "wch,ch347-mfd-i2c";
			};

			ch347-spi {
				compatible = "wch,ch347-mfd-spi";

				spi-nor@0 {
                                        compatible = "jedec,spi-nor";
					reg = <0>;
					spi-max-frequency = <60000000>;
				};
			};
		};
	};
};
```